### PR TITLE
Fix logging bug in index.js

### DIFF
--- a/pulse/index.js
+++ b/pulse/index.js
@@ -3,10 +3,12 @@ var Module = {};
 loadPulse = () => {
   return new Promise((resolve, reject) => {
     fetch('pulse/src/wasmkissfft.wasm')
-    .then(console.log("made it into loadpulse"))
-      .then(response => response.arrayBuffer())
-      .then(console.log("step into m"))
-      .then((m) => {
+      .then(response => {
+        console.log("made it into loadpulse");
+        return response.arrayBuffer();
+      }).then((m) => {
+        console.log("step into m");
+
         Module.wasmBinary = m;
 
         script = document.createElement('script');


### PR DESCRIPTION
The current code will log "made it into loadpulse" and "step into m" as soon as the Promise function is evaluated, rather than logging at the appropriate times. That's because `console.log()` isn't being passed in as part of a callback function body, but is instead passed in as the callback itself (more precisely, `console.log()` is executed and the return value of `undefined` is passed in as the callback). This PR fixes the issue by moving `console.log` statements into function bodies.

Thanks for creating this library, by the way!