### PR TITLE
fixes/improvements to benchmark page

### DIFF
--- a/demo/benchmarks.js
+++ b/demo/benchmarks.js
@@ -80,15 +80,6 @@ function testFFTasm(size) {
 	}
     var ri = inputReals(size);
     var out = fft.forward(ri);
-
-	for (var j = 0; j <= size/2; ++j) {
-	    total += Math.sqrt(out[j*2] * out[j*2] + out[j*2+1] * out[j*2+1]);
-	}
-	// KissFFTR returns only the first half of the output (plus
-	// DC/Nyquist) -- synthesise the conjugate half
-	for (var j = 1; j < size/2; ++j) {
-	    total += Math.sqrt(out[j*2] * out[j*2] + out[j*2+1] * out[j*2+1]);
-	}
     }
 
     var end = performance.now();
@@ -114,10 +105,6 @@ function testFFTCCasm(size) {
 	}
 	var cin = inputInterleaved(size);
     var out = fft.forward(cin);
-
-	for (var j = 0; j < size; ++j) {
-	    total += Math.sqrt(out[j*2] * out[j*2] + out[j*2+1] * out[j*2+1]);
-	}
     }
 
     var end = performance.now();
@@ -141,14 +128,6 @@ function testFFTwasm(size) {
       }
       var ri = inputReals(size);
       var out = fft.forward(ri);
-      for (var j = 0; j <= size/2; ++j) {
-        total += Math.sqrt(out[j*2] * out[j*2] + out[j*2+1] * out[j*2+1]);
-      }
-      // KissFFTR returns only the first half of the output (plus
-      // DC/Nyquist) -- synthesise the conjugate half
-      for (var j = 1; j < size/2; ++j) {
-        total += Math.sqrt(out[j*2] * out[j*2] + out[j*2+1] * out[j*2+1]);
-      }
     }
     var end = performance.now();
 
@@ -172,9 +151,6 @@ function testFFTwasm(size) {
       }
       var cin = inputInterleaved(size);
       var out = fft.forward(cin);
-      for (var j = 0; j < size; ++j) {
-        total += Math.sqrt(out[j*2] * out[j*2] + out[j*2+1] * out[j*2+1]);
-      }
     }
 
     var end = performance.now();
@@ -184,7 +160,7 @@ function testFFTwasm(size) {
     fft.dispose();
   }
 
-var sizes = [ 4, 8, 512, 2048, 4096 ];
+var sizes = [ 4, 8, 512, 2048, 4096, 8192 ];
 var tests = [testFFTasm, testFFTCCasm, testFFTwasm, testFFTCCwasm];
 var nextTest = 0;
 var nextSize = 0;

--- a/demo/benchmarks.js
+++ b/demo/benchmarks.js
@@ -10,54 +10,24 @@ loadPulse()
 function inputReals(size) {
     var result = new Float32Array(size);
     for (var i = 0; i < result.length; i++)
-	result[i] = (i % 2) / 4.0;
-    return result;
-}
-
-function zeroReals(size) {
-    var result = new Float32Array(size);
-    for (var i = 0; i < result.length; i++)
-	result[i] = 0.0;
+	result[i] = (Math.random()*2-1) / 4.0;
     return result;
 }
 
 function inputInterleaved(size) {
     var result = new Float32Array(size*2);
     for (var i = 0; i < size; i++)
-	result[i*2] = (i % 2) / 4.0;
-    return result;
-}
-
-function inputReal64s(size) {
-    var result = new Float64Array(size);
-    for (var i = 0; i < result.length; i++)
-	result[i] = (i % 2) / 4.0;
-    return result;
-}
-
-function zeroReal64s(size) {
-    var result = new Float64Array(size);
-    for (var i = 0; i < result.length; i++)
-	result[i] = 0.0;
-    return result;
-}
-
-function inputComplexArray(size) {
-    var result = new complex_array.ComplexArray(size);
-    for (var i = 0; i < size; i++) {
-	result.real[i] = (i % 2) / 4.0;
-	result.imag[i] = 0.0;
-    }
+	result[i*2] = (Math.random()*2-1) / 4.0;
     return result;
 }
 
 var iterations = 2000;
 
-function report(name, start, middle, end, total) {
+function report(name, start, middle, end, size) {
     function addTo(tag, thing) {
 	    document.getElementById(name + "-" + tag).innerHTML += thing + "<br>";
     }
-    addTo("result", total);
+    addTo("size", size);
     addTo("1", Math.round(middle - start) + " ms");
     addTo("2", Math.round(end - middle) + " ms");
     addTo("itr", Math.round((1000.0 /
@@ -65,8 +35,8 @@ function report(name, start, middle, end, total) {
 }
 
 function testFFTasm(size) {
-
     var fft = new KissFFTR(size);
+    var ri = [...Array(64)].map(() => inputReals(size));
 
     var start = performance.now();
     var middle = start;
@@ -78,20 +48,19 @@ function testFFTasm(size) {
 	if (i == iterations) {
 	    middle = performance.now();
 	}
-    var ri = inputReals(size);
-    var out = fft.forward(ri);
+    var out = fft.forward(ri[i%ri.length]);
     }
 
     var end = performance.now();
 
-    report("kissfft", start, middle, end, total);
+    report("kissfft", start, middle, end, size);
 
     fft.dispose();
 }
 
 function testFFTCCasm(size) {
-
     var fft = new KissFFT(size);
+    var cin = [...Array(64)].map(() => inputInterleaved(size));
 
     var start = performance.now();
     var middle = start;
@@ -103,19 +72,20 @@ function testFFTCCasm(size) {
 	if (i == iterations) {
 	    middle = performance.now();
 	}
-	var cin = inputInterleaved(size);
-    var out = fft.forward(cin);
+    var out = fft.forward(cin[i%cin.length]);
     }
 
     var end = performance.now();
 
-    report("kissfftcc", start, middle, end, total);
+    report("kissfftcc", start, middle, end, size);
 
     fft.dispose();
 }
 
 function testFFTwasm(size) {
     var fft = new pulse.fftReal(size);
+    var ri = [...Array(64)].map(() => inputReals(size));
+  
     var start = performance.now();
     var middle = start;
     var end = start;
@@ -126,18 +96,18 @@ function testFFTwasm(size) {
       if (i == iterations) {
         middle = performance.now();
       }
-      var ri = inputReals(size);
-      var out = fft.forward(ri);
+      var out = fft.forward(ri[i%ri.length]);
     }
     var end = performance.now();
 
-    report("WASMkissfft", start, middle, end, total);
+    report("WASMkissfft", start, middle, end, size);
 
     fft.dispose();
   }
 
   function testFFTCCwasm(size) {
     var fft = new pulse.fftComplex(size);
+    var cin = [...Array(64)].map(() => inputInterleaved(size));
 
     var start = performance.now();
     var middle = start;
@@ -149,13 +119,12 @@ function testFFTwasm(size) {
       if (i == iterations) {
         middle = performance.now();
       }
-      var cin = inputInterleaved(size);
-      var out = fft.forward(cin);
+      var out = fft.forward(cin[i%cin.length]);
     }
 
     var end = performance.now();
 
-    report("WASMkissfftcc", start, middle, end, total);
+    report("WASMkissfftcc", start, middle, end, size);
 
     fft.dispose();
   }

--- a/index.html
+++ b/index.html
@@ -102,6 +102,13 @@
                 <td id="WASMkissfftcc-2"></td>
                 <td id="WASMkissfftcc-itr"></td>
               </tr>
+              <tr>
+                <th scope="row">Alba's first JS FFT (c2c)</th>
+                <td id="JSfftcc-size"></td>
+                <td id="JSfftcc-1"></td>
+                <td id="JSfftcc-2"></td>
+                <td id="JSfftcc-itr"></td>
+              </tr>
             </tbody>
           </table>
           <hr>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             <thead>
               <tr>
                 <th scope="col">Implementation</th>
-                <th scope="col">Buffer Size</th>
+                <th scope="col">FFT points</th>
                 <th scope="col">Time (1st half)</th>
                 <th scope="col">Time (2nd half)</th>
                 <th scope="col">Rate (2nd half)</th>
@@ -76,28 +76,28 @@
             <tbody>
               <tr>
                 <th scope="row">FFT:asm</th>
-                <td id="kissfft-result"></td>
+                <td id="kissfft-size"></td>
                 <td id="kissfft-1"></td>
                 <td id="kissfft-2"></td>
                 <td id="kissfft-itr"></td>
               </tr>
               <tr>
                 <th scope="row">FFT:asm (c2c)</th>
-                <td id="kissfftcc-result"></td>
+                <td id="kissfftcc-size"></td>
                 <td id="kissfftcc-1"></td>
                 <td id="kissfftcc-2"></td>
                 <td id="kissfftcc-itr"></td>
               </tr>
               <tr>
                 <th scope="row">FFT:wasm</th>
-                <td id="WASMkissfft-result"></td>
+                <td id="WASMkissfft-size"></td>
                 <td id="WASMkissfft-1"></td>
                 <td id="WASMkissfft-2"></td>
                 <td id="WASMkissfft-itr"></td>
               </tr>
               <tr>
                 <th scope="row">FFT:wasm (c2c)</th>
-                <td id="WASMkissfftcc-result"></td>
+                <td id="WASMkissfftcc-size"></td>
                 <td id="WASMkissfftcc-1"></td>
                 <td id="WASMkissfftcc-2"></td>
                 <td id="WASMkissfftcc-itr"></td>

--- a/index.html
+++ b/index.html
@@ -109,6 +109,13 @@
                 <td id="JSfftcc-2"></td>
                 <td id="JSfftcc-itr"></td>
               </tr>
+              <tr>
+                <th scope="row">Alba's first WASM FFT (c2c)</th>
+                <td id="JSWASMfftcc-size"></td>
+                <td id="JSWASMfftcc-1"></td>
+                <td id="JSWASMfftcc-2"></td>
+                <td id="JSWASMfftcc-itr"></td>
+              </tr>
             </tbody>
           </table>
           <hr>

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
   </section>
 
   <!-- d3 DCN -->
-  <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+  <script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
   <script src="pulse/index.js"></script>
   <script src="demo/kissFFTasm.js"></script>
   <script src="demo/FFTasm.js"></script>

--- a/pulse/index.js
+++ b/pulse/index.js
@@ -2,7 +2,7 @@ var Module = {};
 
 loadPulse = () => {
   return new Promise((resolve, reject) => {
-    fetch('pulse/src/wasmkissfft.wasm')
+    fetch('pulse/src/WASMkissFFT.wasm')
       .then(response => {
         console.log("made it into loadpulse");
         return response.arrayBuffer();


### PR DESCRIPTION
- Bunch of obvious fixes so that things work again
- Add more sizes
- Make benchmarks a bit more exact by having them *only* calculate FFTs, nothing else
- Add an [FFT I wrote](https://gist.github.com/mildsunrise/d5990a0651009b8c96460c53a3493e03) which is about ~50 lines of code and performs more or less like PulseFFT
- Some other small improvements